### PR TITLE
Change groupId/artifactId to match the other fabric8-quickstarts/spring-boot-camel-*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.fuse</groupId>
-    <artifactId>camel-bridge-springboot-xml</artifactId>
+    <groupId>io.fabric8.quickstarts</groupId>
+    <artifactId>spring-boot-camel-soap-rest-bridge</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>Fabric8 :: Quickstarts :: Spring-Boot :: Camel XML</name>
-    <description>Spring Boot example running a Camel route defined in XML</description>
+    <name>Fabric8 :: Quickstarts :: Spring-Boot :: Camel SOAP/REST Bridge</name>
+    <description>Spring Boot example of how to use Camel's REST DSL to expose a backend SOAP API</description>
     <properties>
         <cxf.version>3.2.7.fuse-sb2-760024-redhat-00001</cxf.version>
         <fuse.bom.version>7.6.0.fuse-sb2-760028-redhat-00001</fuse.bom.version>


### PR DESCRIPTION
I think it would be good to match the groupId / artifactId naming conventions used in the other spring-boot-camel-* quickstarts.

Examples :

https://github.com/fabric8-quickstarts/spring-boot-camel/blob/fuse-7.x.sb2.redhat/pom.xml#L24-L25
https://github.com/fabric8-quickstarts/spring-boot-camel-xml/blob/fuse-7.x.sb2.redhat/pom.xml#L24-L25