### PR TITLE
[ENTESB-15989] Wrong version of docker image in quickstarts pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <cxf.version>3.3.6.fuse-780029</cxf.version>
         <fuse.bom.version>7.8.0.fuse-sb2-780038</fuse.bom.version>
-        <docker.image.version>1.7</docker.image.version>
+        <docker.image.version>1.9</docker.image.version>
         <resteasy.version>3.6.1.Final</resteasy.version>
         <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15989