### PR TITLE
ENTESB-14593: CVE-2020-14338 xercesimpl: wildfly: XML validation mani…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-        <keycloak.version>9.0.9.redhat-00001</keycloak.version>
+        <keycloak.version>9.0.12.redhat-00001</keycloak.version>
         <keycloak.home>${project.build.directory}/rh-sso-7.4</keycloak.home>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
…pulation due to incomplete application of use-grammar-pool-only in xercesImpl

component alignment - upgrade keycloak to 9.0.12.redhat-00001