### PR TITLE
[ENTESB-21273] Remove or refactor non-working quickstart spring-boot-camel-soap-rest-bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.fabric8.quickstarts.soap.bridge</groupId>
+    <groupId>io.fabric8.quickstarts</groupId>
     <artifactId>spring-boot-camel-soap-rest-bridge</artifactId>
     <version>1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-21273

Changing the group id to io.fabric8.quickstarts